### PR TITLE
correzione errore

### DIFF
--- a/JAVA/MARKDOWN/Example07.md
+++ b/JAVA/MARKDOWN/Example07.md
@@ -28,7 +28,7 @@ package it.unipr.informatica.concurrent;
 public interface ExecutorService extends Executor {
 	//...
 	
-	public void submit(Runnable task, Callback<T> callback);
+	public void submit(Runnable task, Callback<?> callback);
 	public <T> void submit(Callable<T> task, Callback<T> callback);
 }
 ```


### PR DESCRIPTION
Callback<T> callback -> sarebbe sbagliato in quanto il tipo non si puo' dedurre a tempo di compilazione.